### PR TITLE
Fixes #3 - Screen Adjustments: Background Transparency, Screen Positioning, and Sizing Fixes

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -231,3 +231,11 @@ Bottom text
     margin: 0;
     font-weight: bold;
 }
+
+#compscreen-container {
+    background-color: rgba(255, 255, 255);
+    border: 2px solid #333;
+    border-radius: 8px;
+    box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.2);
+    overflow: hidden;
+}

--- a/js/script.js
+++ b/js/script.js
@@ -299,7 +299,10 @@ loader.load('./Static/models/desk.glb', (gltf) => {
         cssObject.rotation.x += Math.PI * 0.5;
         cssObject.rotation.y += Math.PI * 0.75;
         cssObject.rotation.z -= Math.PI * 0.25;
-        cssObject.scale.set(0.005, 0.008, 0.005);
+        cssObject.scale.set(0.004, 0.005, 0.005);
+        cssObject.translateX(0.7);
+        cssObject.position.y += 0.2;
+
 
         scene.add(cssObject);
         console.log("CSS3D object added to scene");


### PR DESCRIPTION
This PR tackles a few tweaks from Issue #3:

* Background Transparency: Improved to make everything clearer and look better.
* Screen Positioning: Centered the screen for a more balanced layout.
* Screen Sizing: Adjusted to get a better overall fit.

Note: I couldn’t figure out the pixel ratio fix, so that’s still open for now.
fixes #3 
